### PR TITLE
:memo: Update testing tip with local Mocha tip

### DIFF
--- a/productivity.md
+++ b/productivity.md
@@ -115,14 +115,14 @@ Do one of the following to **define your test task**...
 
 > :bulb: This tip shows how to setup a testing task using gulp and mocha
 
-1. Install mocha: `npm install --global mocha`
+1. Install mocha: `npm install --save-dev mocha`
 2. Create your mocha tests in `.\test\*.js` (i.e. `test.js`)
 3. Create your `test` task in your `gulpfile.js` *(sample test task below)*
 4. Run your `test` task by either the shortcut keys (recommended) `CTRL+SHIFT+T` or command palette `task test`
 
 ```javascript
 gulp.task('test', function (callback) {
-  exec('mocha', function (err, stdout, stderr) {
+  exec('./node_modules/mocha/bin/mocha ./test', function (err, stdout, stderr) {
     console.log(stdout);
     console.log(stderr);
     callback(err);


### PR DESCRIPTION
The Mocha should should be installed locally to never
break a test just because local machine Mocha version is
different then project was tested with.
This tip update shows how to install and use Mocha locally
from Test Gulp based task

I've created a sample VSCode project that demonstrates that tip in real project, ES6 based.
https://github.com/peterblazejewicz/vscode-tips-samples/tree/master/src/productivity

Thanks!
