### PR TITLE
:memo: Add note about adding key bindings on OS X

### DIFF
--- a/git.md
+++ b/git.md
@@ -5,6 +5,11 @@
 1. Switch to the Git workbench view (`CTRL+SHIFT+G`)
 2. Select *initialize repository*
 
+> :bulb: On Mac OS X you may need to add your own key binding for `CMD+SHIFT+G`:
+```
+{"key": "cmd+shift+g", "command": "workbench.view.git"}
+```
+
 ## Commit changes
 
 1. Switch to the Git workbench


### PR DESCRIPTION
The CMD+SHIFT+G - the OS X shortcut for showing Git
workbench view is not enabled by default at the time of
writing.
The hint provides information on how to enable this shorcut
on OS X.

Thanks!
